### PR TITLE
Handle read_multi and fetch_multi with no keys

### DIFF
--- a/lib/readthis/cache.rb
+++ b/lib/readthis/cache.rb
@@ -214,6 +214,7 @@ module Readthis
     #
     def read_multi(*keys)
       options = merged_options(extract_options!(keys))
+      return {} if keys.empty?
       mapping = keys.map { |key| namespaced_key(key, options) }
 
       invoke(:read_multi, keys) do |store|

--- a/spec/readthis/cache_spec.rb
+++ b/spec/readthis/cache_spec.rb
@@ -144,6 +144,10 @@ RSpec.describe Readthis::Cache do
         'e' => 2,
       )
     end
+
+    it 'returns {} with no keys' do
+      expect(cache.read_multi(namespace: 'cache')).to eq({})
+    end
   end
 
   describe '#write_multi' do
@@ -191,6 +195,11 @@ RSpec.describe Readthis::Cache do
 
       expect(cache.read('b')).to be_nil
       expect(cache.read('b', namespace: 'alph')).not_to be_nil
+    end
+
+    it 'return empty results without keys' do
+      results = cache.fetch_multi(namespace: 'alph') { |key| key }
+      expect(results).to eq({})
     end
   end
 


### PR DESCRIPTION
In instances when `read_multi` or `fetch_mutli` are called no keys, Redis throws this error:

    ERR wrong number of arguments for 'mget' command

This PR is to handle this case gracefully following the behavior of `ActiveSupport::Cache::FileStore`.  Both added tests include a `namespace` option to make sure the empty check happens after `extract_options!`