### PR TITLE
Compression option is broken, it doesn't unload data

### DIFF
--- a/spec/readthis/entity_spec.rb
+++ b/spec/readthis/entity_spec.rb
@@ -51,6 +51,15 @@ RSpec.describe Readthis::Entity do
       expect(entity.load(compressed)).not_to eq(string)
     end
 
+    it 'does not fail when compressed data size is below threshold' do
+      # This string has very little entropy thus compression ratio is huge
+      string = 'a' * 200
+      entity = Readthis::Entity.new(compress: true, threshold: 50)
+      # Store and reload the entity will not return the same value
+      # when compressed length is below threshold
+      expect(entity.load(entity.dump(string))).to eq string
+    end
+
     it 'does not try to load a nil value' do
       entity = Readthis::Entity.new
 


### PR DESCRIPTION
When compressed data size is below the compression threshold data loading is completely wrong. It will return the compressed data.

This is likely to happen when cached data has low entropy and compress well (html, json, etc). You should really put a big warning on this because in production this can make disasters.

Attached is a failing spec, the main issue is in [this line](https://github.com/sorentwo/readthis/blob/master/lib/readthis/entity.rb#L28), you cannot check if value is compressed comparing its compressing size with threshold value.

To fix that in a reliable way you should save a compression flag along with compressed data, or you can try to guess if compression is on by looking at first bytes and check if they matches [zlib format](http://www.faqs.org/rfcs/rfc1950.html).

However I think that the very best option is to introduce some metadata in data you store (e.g. first byte contain your flags), in this way in the future you can swap compressors and support other options, [dalli](https://github.com/mperham/dalli/blob/819dc9dce78aa678233ba58722a6f3dd6b6ff508/lib/dalli/server.rb#L434) does that in this way.

Since this it's a pretty big change (and potentially a breaking change) I won't try to submit a fix before discussing this with you.

I'd like to switch to redis for caching to get rid of memcache extensions but this is for me a stopper issue.