### PR TITLE
Store dumping options within entities

### DIFF
--- a/benchmarks/composing.rb
+++ b/benchmarks/composing.rb
@@ -1,0 +1,29 @@
+require 'benchmark/ips'
+
+def compose_a(marshal, compress)
+  prefix = ''
+  prefix << 'R|'.freeze
+  prefix << marshal.name.ljust(24)
+  prefix << (compress ? '1'.freeze : '0'.freeze)
+  prefix << 1
+  prefix << '|R'.freeze
+end
+
+def compose_b(marshal, compress)
+  "R|#{marshal.name.ljust(24)}#{compress ? '1'.freeze : '0'.freeze}1|R"
+end
+
+def compose_c(marshal, compress)
+  name = marshal.name.ljust(24)
+  comp = compress ? '1'.freeze : '0'.freeze
+
+  "R|#{name}#{comp}1|R"
+end
+
+Benchmark.ips do |x|
+  x.report('a') { compose_a(Marshal, true) }
+  x.report('b') { compose_b(Marshal, true) }
+  x.report('c') { compose_c(Marshal, true) }
+
+  x.compare!
+end

--- a/benchmarks/generic.rb
+++ b/benchmarks/generic.rb
@@ -1,0 +1,34 @@
+require 'bundler'
+
+Bundler.setup
+
+require 'benchmark/ips'
+require 'readthis'
+require 'json'
+
+READTHIS = Readthis::Cache.new(
+  expires_in: 120,
+  marshal: JSON,
+  compress: true
+)
+
+def write_key(key)
+  READTHIS.write(key, key.to_s * 2048)
+end
+
+KEYS = (1..1_000).to_a
+KEYS.each { |key| write_key(key) }
+
+Benchmark.ips do |x|
+  x.report 'readthis:write' do
+    write_key(KEYS.sample)
+  end
+
+  x.report 'readthis:read' do
+    READTHIS.read(KEYS.sample)
+  end
+
+  x.report 'readthis:read_multi' do
+    READTHIS.read(KEYS.sample(30))
+  end
+end

--- a/benchmarks/generic.rb
+++ b/benchmarks/generic.rb
@@ -1,7 +1,3 @@
-require 'bundler'
-
-Bundler.setup
-
 require 'benchmark/ips'
 require 'readthis'
 require 'json'

--- a/benchmarks/parsing.rb
+++ b/benchmarks/parsing.rb
@@ -1,0 +1,28 @@
+require 'benchmark/ips'
+
+def parse_a(string)
+  marshal  = string[2, 12].strip
+  compress = string[15] == '1'.freeze
+
+  [marshal, compress, string[18..-1]]
+end
+
+def parse_b(marked)
+  prefix = marked[0, 32].scrub('*'.freeze)[/R\|(.*)\|R/, 1]
+  offset = prefix.size + 4
+
+  marshal, c_name, _ = prefix.split('|'.freeze)
+
+  compress = c_name == 'true'.freeze
+
+  [marshal, compress, marked[offset..-1]]
+end
+
+STR = 'R|marshal      0|Rafdlkadfjadfj asdlkfjasdlfkj asdlfkjdasflkjadsflkjadslkjfadslkjfasdlkjfadlskjf laksdjflkajsdflkjadsflkadjsfladskjf laksjflakdjfalsdkjfadlskjf laksdjflkajdsflk j'
+
+Benchmark.ips do |x|
+  x.report('a') { parse_a(STR) }
+  x.report('b') { parse_b(STR) }
+
+  x.compare!
+end

--- a/lib/readthis/cache.rb
+++ b/lib/readthis/cache.rb
@@ -310,7 +310,7 @@ module Readthis
     # @example
     #
     #   cache.clear #=> 'OK'
-    def clear(options = {})
+    def clear(_options = nil)
       invoke(:clear, '*', &:flushdb)
     end
 

--- a/lib/readthis/cache.rb
+++ b/lib/readthis/cache.rb
@@ -318,11 +318,12 @@ module Readthis
 
     def write_entity(key, value, store, options)
       namespaced = namespaced_key(key, options)
+      dumped = entity.dump(value, options)
 
       if expiration = options[:expires_in]
-        store.setex(namespaced, expiration.to_i, entity.dump(value))
+        store.setex(namespaced, expiration.to_i, dumped)
       else
-        store.set(namespaced, entity.dump(value))
+        store.set(namespaced, dumped)
       end
     end
 

--- a/lib/readthis/entity.rb
+++ b/lib/readthis/entity.rb
@@ -2,13 +2,13 @@ require 'zlib'
 
 module Readthis
   class Entity
+    MARKER_VERSION = '1'.freeze
+
     DEFAULT_OPTIONS = {
       compress:  false,
       marshal:   Marshal,
       threshold: 8 * 1024
     }.freeze
-
-    MAGIC_BYTES = [120, 156].freeze
 
     def initialize(options = {})
       @options = DEFAULT_OPTIONS.merge(options)
@@ -19,16 +19,39 @@ module Readthis
       threshold = with_fallback(options, :threshold)
       compress  = with_fallback(options, :compress)
 
-      deflate(marshal.dump(value), compress, threshold)
+      dumped = deflate(marshal.dump(value), compress, threshold)
+
+      Readthis::Marker.compose(dumped, marshal, compress)
     end
 
-    def load(value, options = {})
-      marshal  = with_fallback(options, :marshal)
-      compress = with_fallback(options, :compress)
+    def load(string)
+      marshal, compress, value = Readthis::Marker.decompose(string)
 
       marshal.load(inflate(value, compress))
     rescue TypeError
-      value
+      string
+    end
+
+    def compose(value, marshal, compress)
+      prefix = "RDS|#{marshal.name}|#{compress}|#{MARKER_VERSION}|RDS"
+
+      value.prepend(prefix)
+    end
+
+    def decompose(marked)
+      if marked[0, 3] == 'RDS'.freeze
+        prefix = marked[0, 32][/RDS\|(.*)\|RDS/, 1]
+        offset = prefix.size + 8
+
+        m_name, c_name, _ = prefix.split('|'.freeze)
+
+        marshal  = Kernel.const_get(m_name)
+        compress = c_name == 'true'.freeze
+
+        [marshal, compress, marked[offset..-1]]
+      else
+        [@options[:marshal], @options[:compress], marked]
+      end
     end
 
     private
@@ -42,7 +65,7 @@ module Readthis
     end
 
     def inflate(value, decompress)
-      if decompress && value[0, 2].bytes == MAGIC_BYTES
+      if decompress
         Zlib::Inflate.inflate(value)
       else
         value

--- a/lib/readthis/entity.rb
+++ b/lib/readthis/entity.rb
@@ -35,7 +35,7 @@ module Readthis
     def compose(value, marshal, compress)
       prefix = ''
       prefix << 'R|'.freeze
-      prefix << marshal.name.ljust(16)
+      prefix << marshal.name.ljust(24)
       prefix << (compress ? '1'.freeze : '0'.freeze)
       prefix << MARKER_VERSION
       prefix << '|R'.freeze
@@ -45,10 +45,10 @@ module Readthis
 
     def decompose(marked)
       if marked && marked[0, 2] == 'R|'.freeze
-        marshal  = Kernel.const_get(marked[2, 16].strip)
-        compress = marked[19] == '1'.freeze
+        marshal  = Kernel.const_get(marked[2, 24].strip)
+        compress = marked[27] == '1'.freeze
 
-        [marshal, compress, marked[22..-1]]
+        [marshal, compress, marked[30..-1]]
       else
         [@options[:marshal], @options[:compress], marked]
       end

--- a/lib/readthis/entity.rb
+++ b/lib/readthis/entity.rb
@@ -33,15 +33,15 @@ module Readthis
     end
 
     def compose(value, marshal, compress)
-      prefix = "|#{marshal.name}|#{compress}|#{MARKER_VERSION}|"
+      prefix = "R|#{marshal.name}|#{compress}|#{MARKER_VERSION}|R"
 
       value.prepend(prefix)
     end
 
     def decompose(marked)
-      if marked[0] == '|'.freeze
-        prefix = marked[0, 32][/\|(.*)\|/, 1]
-        offset = prefix.size + 2
+      if marked && marked[0, 2] == 'R|'.freeze
+        prefix = marked[0, 32].scrub('*'.freeze)[/R\|(.*)\|R/, 1]
+        offset = prefix.size + 4
 
         m_name, c_name, _ = prefix.split('|'.freeze)
 

--- a/lib/readthis/entity.rb
+++ b/lib/readthis/entity.rb
@@ -21,11 +21,11 @@ module Readthis
 
       dumped = deflate(marshal.dump(value), compress, threshold)
 
-      Readthis::Marker.compose(dumped, marshal, compress)
+      compose(dumped, marshal, compress)
     end
 
     def load(string)
-      marshal, compress, value = Readthis::Marker.decompose(string)
+      marshal, compress, value = decompose(string)
 
       marshal.load(inflate(value, compress))
     rescue TypeError
@@ -33,15 +33,15 @@ module Readthis
     end
 
     def compose(value, marshal, compress)
-      prefix = "RDS|#{marshal.name}|#{compress}|#{MARKER_VERSION}|RDS"
+      prefix = "|#{marshal.name}|#{compress}|#{MARKER_VERSION}|"
 
       value.prepend(prefix)
     end
 
     def decompose(marked)
-      if marked[0, 3] == 'RDS'.freeze
-        prefix = marked[0, 32][/RDS\|(.*)\|RDS/, 1]
-        offset = prefix.size + 8
+      if marked[0] == '|'.freeze
+        prefix = marked[0, 32][/\|(.*)\|/, 1]
+        offset = prefix.size + 2
 
         m_name, c_name, _ = prefix.split('|'.freeze)
 

--- a/lib/readthis/entity.rb
+++ b/lib/readthis/entity.rb
@@ -33,12 +33,9 @@ module Readthis
     end
 
     def compose(value, marshal, compress)
-      prefix = ''
-      prefix << 'R|'.freeze
-      prefix << marshal.name.ljust(24)
-      prefix << (compress ? '1'.freeze : '0'.freeze)
-      prefix << MARKER_VERSION
-      prefix << '|R'.freeze
+      name   = marshal.name.ljust(24)
+      comp   = compress ? '1'.freeze : '0'.freeze
+      prefix = "R|#{name}#{comp}#{MARKER_VERSION}|R"
 
       value.prepend(prefix)
     end

--- a/lib/readthis/entity.rb
+++ b/lib/readthis/entity.rb
@@ -42,7 +42,7 @@ module Readthis
     end
 
     def inflate(value, decompress)
-      if decompress && value[0, 2].unpack('CC'.freeze) == MAGIC_BYTES
+      if decompress && value[0, 2].bytes == MAGIC_BYTES
         Zlib::Inflate.inflate(value)
       else
         value

--- a/lib/readthis/entity.rb
+++ b/lib/readthis/entity.rb
@@ -33,22 +33,22 @@ module Readthis
     end
 
     def compose(value, marshal, compress)
-      prefix = "R|#{marshal.name}|#{compress}|#{MARKER_VERSION}|R"
+      prefix = ''
+      prefix << 'R|'.freeze
+      prefix << marshal.name.ljust(16)
+      prefix << (compress ? '1'.freeze : '0'.freeze)
+      prefix << MARKER_VERSION
+      prefix << '|R'.freeze
 
       value.prepend(prefix)
     end
 
     def decompose(marked)
       if marked && marked[0, 2] == 'R|'.freeze
-        prefix = marked[0, 32].scrub('*'.freeze)[/R\|(.*)\|R/, 1]
-        offset = prefix.size + 4
+        marshal  = Kernel.const_get(marked[2, 16].strip)
+        compress = marked[19] == '1'.freeze
 
-        m_name, c_name, _ = prefix.split('|'.freeze)
-
-        marshal  = Kernel.const_get(m_name)
-        compress = c_name == 'true'.freeze
-
-        [marshal, compress, marked[offset..-1]]
+        [marshal, compress, marked[22..-1]]
       else
         [@options[:marshal], @options[:compress], marked]
       end

--- a/spec/readthis/cache_spec.rb
+++ b/spec/readthis/cache_spec.rb
@@ -83,15 +83,15 @@ RSpec.describe Readthis::Cache do
   end
 
   describe 'compression' do
-    it 'round trips entries when compression is enabled' do
+    it 'roundtrips entries when compression is enabled' do
       com_cache = Readthis::Cache.new(compress: true, compression_threshold: 8)
       raw_cache = Readthis::Cache.new
       value = 'enough text that it should be compressed'
 
       com_cache.write('compressed', value)
 
-      expect(raw_cache.read('compressed')).not_to eq(value)
       expect(com_cache.read('compressed')).to eq(value)
+      expect(raw_cache.read('compressed')).to eq(value)
     end
 
     it 'round trips bulk entries when compression is enabled' do

--- a/spec/readthis/cache_spec.rb
+++ b/spec/readthis/cache_spec.rb
@@ -94,7 +94,16 @@ RSpec.describe Readthis::Cache do
       expect(raw_cache.read('compressed')).to eq(value)
     end
 
-    it 'round trips bulk entries when compression is enabled' do
+    it 'roundtrips entries with option overrides' do
+      cache = Readthis::Cache.new(compress: false)
+      value = 'enough text that it should be compressed'
+
+      cache.write('comp-round', value, marshal: JSON, compress: true, threshold: 8)
+
+      expect(cache.read('comp-round')).to eq(value)
+    end
+
+    it 'roundtrips bulk entries when compression is enabled' do
       cache = Readthis::Cache.new(compress: true, compression_threshold: 8)
       value = 'also enough text to compress'
 

--- a/spec/readthis/entity_spec.rb
+++ b/spec/readthis/entity_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Readthis::Entity do
       string = 'the quick brown fox'
       marked = Readthis::Entity.new.compose(string, Marshal, true)
 
-      expect(marked).to include('RDS|Marshal|true|1|RDS')
+      expect(marked).to include('|Marshal|true|1|')
       expect(marked).to include(string)
     end
   end

--- a/spec/readthis/entity_spec.rb
+++ b/spec/readthis/entity_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Readthis::Entity do
       string = 'the quick brown fox'
       marked = Readthis::Entity.new.compose(string, Marshal, true)
 
-      expect(marked).to include('|Marshal|true|1|')
+      expect(marked).to include('R|Marshal|true|1|R')
       expect(marked).to include(string)
     end
   end
@@ -140,6 +140,13 @@ RSpec.describe Readthis::Entity do
       expect(marshal).to eq(Marshal)
       expect(compress).to eq(false)
       expect(value).to eq(string)
+    end
+
+    it 'returns defaults with a nil string' do
+      entity = Readthis::Entity.new
+      marshal, compress, value = entity.decompose(nil)
+
+      expect(value).to eq(nil)
     end
   end
 end

--- a/spec/readthis/entity_spec.rb
+++ b/spec/readthis/entity_spec.rb
@@ -1,4 +1,5 @@
 require 'readthis/entity'
+require 'readthis/passthrough'
 require 'json'
 
 RSpec.describe Readthis::Entity do
@@ -114,7 +115,8 @@ RSpec.describe Readthis::Entity do
       string = 'the quick brown fox'
       marked = Readthis::Entity.new.compose(string, Marshal, true)
 
-      expect(marked).to include('R|Marshal         11|R')
+      expect(marked).to match(/R\|.+\|R/)
+      expect(marked).to include('Marshal')
       expect(marked).to include(string)
     end
   end
@@ -130,6 +132,18 @@ RSpec.describe Readthis::Entity do
       expect(marshal).to eq(JSON)
       expect(compress).to eq(true)
       expect(value).to eq(string)
+    end
+
+    it 'can reconstruct longer qualified module names' do
+      string = 'a' * 30
+      entity = Readthis::Entity.new
+      marked = entity.compose(string, Readthis::Passthrough, false)
+
+      expect(marked).to include('Readthis::Passthrough')
+
+      marshal, _, value = entity.decompose(marked)
+
+      expect(marshal).to eq(Readthis::Passthrough)
     end
 
     it 'returns the original string without a marker' do

--- a/spec/readthis/entity_spec.rb
+++ b/spec/readthis/entity_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Readthis::Entity do
       string = 'the quick brown fox'
       marked = Readthis::Entity.new.compose(string, Marshal, true)
 
-      expect(marked).to include('R|Marshal|true|1|R')
+      expect(marked).to include('R|Marshal         11|R')
       expect(marked).to include(string)
     end
   end

--- a/spec/readthis/entity_spec.rb
+++ b/spec/readthis/entity_spec.rb
@@ -7,21 +7,21 @@ RSpec.describe Readthis::Entity do
       string = 'some string'
       entity = Readthis::Entity.new
 
-      expect(entity.dump(string)).to eq(Marshal.dump(string))
+      expect(entity.dump(string)).to include(Marshal.dump(string))
     end
 
     it 'marshals using a custom marshaller' do
       string = 'some string'
       entity = Readthis::Entity.new(marshal: JSON)
 
-      expect(entity.dump(string)).to eq(JSON.dump(string))
+      expect(entity.dump(string)).to include(JSON.dump(string))
     end
 
     it 'overrides the marshaller' do
       string = 'still some string'
       entity = Readthis::Entity.new
 
-      expect(entity.dump(string, marshal: JSON)).to eq(JSON.dump(string))
+      expect(entity.dump(string, marshal: JSON)).to include(JSON.dump(string))
     end
 
     it 'applies compression when enabled' do
@@ -78,14 +78,6 @@ RSpec.describe Readthis::Entity do
       expect(entity.load(dumped)).to eq(object)
     end
 
-    it 'unmarshals with a custom marshaller per method call' do
-      object = [1, 2, 3]
-      dumped = JSON.dump(object)
-      entity = Readthis::Entity.new
-
-      expect(entity.load(dumped, marshal: JSON)).to eq(object)
-    end
-
     it 'uncompresses when compression is enabled' do
       string = 'another one of those huge strings'
       entity = Readthis::Entity.new(compress: true, threshold: 4)
@@ -94,10 +86,13 @@ RSpec.describe Readthis::Entity do
       expect(entity.load(dumped)).not_to eq(string)
     end
 
-    it 'does not try to load a nil value' do
-      entity = Readthis::Entity.new
+    it 'uses the dumped value to define load options' do
+      value   = [1, 2, 3]
+      custom  = Readthis::Entity.new(marshal: JSON, compress: true)
+      general = Readthis::Entity.new(marshal: Marshal, compress: false)
+      dumped  = custom.dump(value)
 
-      expect(entity.load(nil)).to be_nil
+      expect(general.load(dumped)).to eq(value)
     end
 
     it 'passes through the value when it fails to marshal' do
@@ -111,6 +106,40 @@ RSpec.describe Readthis::Entity do
       dumped = Marshal.dump('some sizable string')
 
       expect { entity.load(dumped) }.not_to raise_error
+    end
+  end
+
+  describe '#compose' do
+    it 'prepends the string with a formatted marker' do
+      string = 'the quick brown fox'
+      marked = Readthis::Entity.new.compose(string, Marshal, true)
+
+      expect(marked).to include('RDS|Marshal|true|1|RDS')
+      expect(marked).to include(string)
+    end
+  end
+
+  describe '#decompose' do
+    it 'returns extracted options and values' do
+      string = 'the quick brown fox'
+      entity = Readthis::Entity.new
+      marked = entity.compose(string.dup, JSON, true)
+
+      marshal, compress, value = entity.decompose(marked)
+
+      expect(marshal).to eq(JSON)
+      expect(compress).to eq(true)
+      expect(value).to eq(string)
+    end
+
+    it 'returns the original string without a marker' do
+      string = 'the quick brown fox'
+      entity = Readthis::Entity.new
+      marshal, compress, value = entity.decompose(string)
+
+      expect(marshal).to eq(Marshal)
+      expect(compress).to eq(false)
+      expect(value).to eq(string)
     end
   end
 end


### PR DESCRIPTION
This introduces "persistent" options stored along with entities. That means when an entity was stored using `JSON` for marshaling and compression was enabled that entity can be loaded later, regardless of what the options currently are. Additionally, options can be specified per-call, so even when the instance is configured to use `JSON` for marshaling you can pass through `marshal: Readthis::Passthrough` for particular entities. There isn't any need to remember in your code which entities were written with which marshal, the same marshaller will be used for dumping. This grants a lot of flexibility and prevents unexpected errors when switching instance options.

The implementation relies on a fixed size header prepended to the entity body. There are benchmarks in the repository explaining the decision to use fixed size headers. Essentially they are quite a bit faster and more predictable.