### PR TITLE
ActiveSupport expects a hash as a payload for notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
   writes a value (`write`, `fetch`, etc). For example, this allows certain
   entities to be cached as JSON while all other entities are cached using
   Marshal.
+- Breaking: A hash containing the cache key is passed as the payload for
+  `ActiveSupport::Notifications` instrumentation, rather than the key directly.
+  This moves the implementation in-line with the tests for the code, and
+  prevents errors from being masked when an error occurs inside an instrumented
+  block. [readthis#20][pull-20]. Discovered by @banister and fixed by @workmad3.
 
 [pull-17]: https://github.com/sorentwo/readthis/pull/17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   block. [readthis#20][pull-20]. Discovered by @banister and fixed by @workmad3.
 
 [pull-17]: https://github.com/sorentwo/readthis/pull/17
+[pull-20]: https://github.com/sorentwo/readthis/pull/20
 
 ## v0.8.1 2015-09-04
 

--- a/lib/readthis/cache.rb
+++ b/lib/readthis/cache.rb
@@ -340,7 +340,7 @@ module Readthis
       name    = "cache_#{operation}.active_support"
       payload = { key: key }
 
-      self.class.notifications.instrument(name, key) { yield(payload) }
+      self.class.notifications.instrument(name, payload) { yield(payload) }
     end
 
     def invoke(operation, key, &block)


### PR DESCRIPTION
ActiveSupport expects a hash to be passed as the payload to `instrument`. In the majority of cases, not passing a hash doesn't cause any incorrect behaviour. 

However, if the block passed to `instrument` raises an Exception, ActiveSupport::Notifications will attempt to add an `:exception` key to the payload hash. When this occurs within a cache fetch for ReadThis, the end result is a `TypeError` from deep inside the cache code, unrelated to the original exception. (https://github.com/rails/rails/blob/30af171af13293aa37bee612ae7b976d3ede0439/activesupport/lib/active_support/notifications.rb#L64)

(credit goes to @banister for figuring out this edge case) 