### PR TITLE
Enable customizing serializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,11 @@ Readthis uses Ruby's `Marshal` module for dumping and loading all values by
 default. This isn't always the fastest option, and depending on your use case it
 may be desirable to use a faster but less flexible marshaller.
 
-Use Oj for JSON marshalling, extremely fast, but supports limited types:
+By default Readthis knows about 3 different serializers for marshalling:
 
-```ruby
-Readthis::Cache.new(marshal: Oj)
-```
+* Marshal
+* JSON
+* Passthrough
 
 If all cached data can safely be represented as a string then use the
 pass-through marshaller:
@@ -114,6 +114,24 @@ pass-through marshaller:
 ```ruby
 Readthis::Cache.new(marshal: Readthis::Passthrough)
 ```
+
+You can introduce up to four additional marshals by configuring `serializers` on
+the Readthis module. For example, if you wanted to use Oj for JSON marshalling,
+it is extremely fast, but supports limited types:
+
+```ruby
+Readthis.serializers << Oj
+
+# Freeze the serializers to ensure they aren't changed at runtime.
+Readthis.serializers.freeze!
+
+Readthis::Cache.new(marshal: Oj)
+```
+
+Be aware that the order in which you add serializers matters. Serializers are
+sticky and a flag is stored with each cached value. If you subsequently go to
+deserialize values and haven't configured the same serializers in the same order
+your application will raise errors.
 
 ## Differences From ActiveSupport::Cache
 

--- a/lib/readthis.rb
+++ b/lib/readthis.rb
@@ -1,5 +1,11 @@
 require 'readthis/cache'
 require 'readthis/version'
+require 'readthis/serializers'
 
 module Readthis
+  extend self
+
+  def serializers
+    @serializers ||= Readthis::Serializers.new
+  end
 end

--- a/lib/readthis.rb
+++ b/lib/readthis.rb
@@ -1,6 +1,6 @@
 require 'readthis/cache'
-require 'readthis/version'
 require 'readthis/serializers'
+require 'readthis/version'
 
 module Readthis
   extend self

--- a/lib/readthis/serializers.rb
+++ b/lib/readthis/serializers.rb
@@ -15,43 +15,83 @@ module Readthis
 
     attr_reader :serializers, :inverted
 
+    # Creates a new Readthis::Serializers entity. No configuration is expected
+    # during initialization.
+    #
     def initialize
       reset!
     end
 
+    # Append a new serializer. Up to 7 total serializers may be configured for
+    # any single application be configured for any single application. This
+    # limit is based on the number of bytes available in the option flag.
+    #
+    # @param [Module] Any object that responds to `dump` and `load`
+    # @return [self] Returns itself for possible chaining
+    #
+    # @example
+    #
+    #     serializers = Readthis::Serializers.new
+    #     serializers << Oj
+    #
     def <<(serializer)
       case
       when serializers.frozen?
         raise SerializersFrozenError
-      when serializers.length >= SERIALIZER_LIMIT
+      when serializers.length > SERIALIZER_LIMIT
         raise SerializersLimitError
       else
         @serializers[serializer] = flags.max.succ
         @inverted = @serializers.invert
       end
+
+      self
     end
 
-    def assoc(marshal)
-      serializers[marshal]
-    end
-
-    def rassoc(flag)
-      inverted[flag]
-    end
-
+    # Freeze the serializers hash, preventing modification.
+    #
     def freeze!
       serializers.freeze
     end
 
+    # Reset the instance back to the default state. Useful for cleanup during
+    # testing.
+    #
     def reset!
       @serializers = BASE_SERIALIZERS.dup
       @inverted = @serializers.invert
     end
 
+    # Find a flag by the marshal object.
+    #
+    # @param [Object] Look up a flag by object
+    # @return [Number] Corresponding flag for the marshal object
+    #
+    # @example
+    #
+    #   serializers.assoc(Marshal) #=> 1
+    #
+    def assoc(marshal)
+      serializers[marshal]
+    end
+
+    # Find a marshal object by flag value.
+    #
+    # @param [Number] Flag to look up the marshal object by
+    # @return [Module] The marshal object
+    #
+    def rassoc(flag)
+      inverted[flag]
+    end
+
+    # The current list of marshal objects.
+    #
     def marshals
       serializers.keys
     end
 
+    # The current list of flags.
+    #
     def flags
       serializers.values
     end

--- a/lib/readthis/serializers.rb
+++ b/lib/readthis/serializers.rb
@@ -16,7 +16,7 @@ module Readthis
     attr_reader :serializers
 
     def initialize
-      @serializers = BASE_SERIALIZERS.dup
+      reset!
     end
 
     def inverted
@@ -34,11 +34,19 @@ module Readthis
       end
     end
 
+    def [](marshal)
+      serializers[marshal]
+    end
+
     def freeze!
       serializers.freeze
     end
 
-    def modules
+    def reset!
+      @serializers = BASE_SERIALIZERS.dup
+    end
+
+    def marshals
       serializers.keys
     end
 

--- a/lib/readthis/serializers.rb
+++ b/lib/readthis/serializers.rb
@@ -1,0 +1,49 @@
+require 'readthis/passthrough'
+
+module Readthis
+  SerializersFrozenError = Class.new(Exception)
+  SerializersLimitError  = Class.new(Exception)
+
+  class Serializers
+    BASE_SERIALIZERS = {
+      Marshal     => 0x1,
+      Passthrough => 0x2,
+      JSON        => 0x3
+    }.freeze
+
+    SERIALIZER_LIMIT = 7
+
+    attr_reader :serializers
+
+    def initialize
+      @serializers = BASE_SERIALIZERS.dup
+    end
+
+    def inverted
+      serializers.invert
+    end
+
+    def <<(serializer)
+      case
+      when serializers.frozen?
+        raise SerializersFrozenError
+      when serializers.length >= SERIALIZER_LIMIT
+        raise SerializersLimitError
+      else
+        @serializers[serializer] = flags.max.succ
+      end
+    end
+
+    def freeze!
+      serializers.freeze
+    end
+
+    def modules
+      serializers.keys
+    end
+
+    def flags
+      serializers.values
+    end
+  end
+end

--- a/lib/readthis/serializers.rb
+++ b/lib/readthis/serializers.rb
@@ -13,14 +13,10 @@ module Readthis
 
     SERIALIZER_LIMIT = 7
 
-    attr_reader :serializers
+    attr_reader :serializers, :inverted
 
     def initialize
       reset!
-    end
-
-    def inverted
-      serializers.invert
     end
 
     def <<(serializer)
@@ -31,11 +27,16 @@ module Readthis
         raise SerializersLimitError
       else
         @serializers[serializer] = flags.max.succ
+        @inverted = @serializers.invert
       end
     end
 
-    def [](marshal)
+    def assoc(marshal)
       serializers[marshal]
+    end
+
+    def rassoc(flag)
+      inverted[flag]
     end
 
     def freeze!
@@ -44,6 +45,7 @@ module Readthis
 
     def reset!
       @serializers = BASE_SERIALIZERS.dup
+      @inverted = @serializers.invert
     end
 
     def marshals

--- a/spec/readthis/cache_spec.rb
+++ b/spec/readthis/cache_spec.rb
@@ -1,4 +1,4 @@
-require 'readthis/cache'
+require 'readthis'
 
 RSpec.describe Readthis::Cache do
   let(:cache) { Readthis::Cache.new }
@@ -79,6 +79,30 @@ RSpec.describe Readthis::Cache do
   describe '#read' do
     it 'gracefully handles nil options' do
       expect { cache.read('whatever', nil) }.not_to raise_error
+    end
+  end
+
+  describe 'serializers' do
+    after do
+      Readthis.serializers.reset!
+    end
+
+    it 'uses globally configured serializers' do
+      custom = Class.new do
+        def self.dump(_)
+          'dumped'
+        end
+
+        def self.load(_)
+          'dumped'
+        end
+      end
+
+      Readthis.serializers << custom
+
+      cache.write('customized', 'overwrite me', marshal: custom)
+
+      expect(cache.read('customized')).to include('dumped')
     end
   end
 

--- a/spec/readthis/entity_spec.rb
+++ b/spec/readthis/entity_spec.rb
@@ -1,5 +1,4 @@
-require 'readthis/entity'
-require 'readthis/passthrough'
+require 'readthis'
 require 'json'
 
 RSpec.describe Readthis::Entity do

--- a/spec/readthis/serializers_spec.rb
+++ b/spec/readthis/serializers_spec.rb
@@ -1,0 +1,58 @@
+require 'readthis/serializers'
+
+RSpec.describe Readthis::Serializers do
+  CustomSerializer  = Class.new
+  AnotherSerializer = Class.new
+
+  describe '#<<' do
+    it 'appends new serializers' do
+      serializers = Readthis::Serializers.new
+
+      serializers << CustomSerializer
+
+      expect(serializers.modules).to include(CustomSerializer)
+      expect(serializers.flags).to eq((1..4).to_a)
+      expect(serializers.serializers).to include(
+        CustomSerializer => 4
+      )
+    end
+
+    it 'increments flags' do
+      serializers = Readthis::Serializers.new
+      serializers << CustomSerializer
+      serializers << AnotherSerializer
+
+      expect(serializers.flags).to eq((1..5).to_a)
+    end
+
+    it 'prevents more than seven serializers' do
+      serializers = Readthis::Serializers.new
+
+      expect {
+        10.times { serializers << Class.new }
+      }.to raise_error(Readthis::SerializersLimitError)
+    end
+  end
+
+  describe '#inverted' do
+    it 'inverts the current set of serializers' do
+      serializers = Readthis::Serializers.new
+
+      expect(serializers.inverted).to include(
+        1 => Marshal
+      )
+    end
+  end
+
+  describe '#freeze' do
+    it 'does now allow appending after freeze' do
+      serializers = Readthis::Serializers.new
+
+      serializers.freeze!
+
+      expect {
+        serializers << CustomSerializer
+      }.to raise_error(Readthis::SerializersFrozenError)
+    end
+  end
+end

--- a/spec/readthis/serializers_spec.rb
+++ b/spec/readthis/serializers_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Readthis::Serializers do
 
       serializers << CustomSerializer
 
-      expect(serializers.modules).to include(CustomSerializer)
+      expect(serializers.marshals).to include(CustomSerializer)
       expect(serializers.flags).to eq((1..4).to_a)
       expect(serializers.serializers).to include(
         CustomSerializer => 4
@@ -34,6 +34,14 @@ RSpec.describe Readthis::Serializers do
     end
   end
 
+  describe '#[]' do
+    it 'looks up serializers by module' do
+      serializers = Readthis::Serializers.new
+
+      expect(serializers[Marshal]).to eq(0x1)
+    end
+  end
+
   describe '#inverted' do
     it 'inverts the current set of serializers' do
       serializers = Readthis::Serializers.new
@@ -44,7 +52,7 @@ RSpec.describe Readthis::Serializers do
     end
   end
 
-  describe '#freeze' do
+  describe '#freeze!' do
     it 'does now allow appending after freeze' do
       serializers = Readthis::Serializers.new
 
@@ -53,6 +61,17 @@ RSpec.describe Readthis::Serializers do
       expect {
         serializers << CustomSerializer
       }.to raise_error(Readthis::SerializersFrozenError)
+    end
+  end
+
+  describe '#reset!' do
+    it 'reverts back to the original set of serializers' do
+      serializers = Readthis::Serializers.new
+
+      serializers << Class.new
+      serializers.reset!
+
+      expect(serializers.marshals.length).to eq(3)
     end
   end
 end

--- a/spec/readthis/serializers_spec.rb
+++ b/spec/readthis/serializers_spec.rb
@@ -12,9 +12,6 @@ RSpec.describe Readthis::Serializers do
 
       expect(serializers.marshals).to include(CustomSerializer)
       expect(serializers.flags).to eq((1..4).to_a)
-      expect(serializers.serializers).to include(
-        CustomSerializer => 4
-      )
     end
 
     it 'increments flags' do
@@ -34,21 +31,19 @@ RSpec.describe Readthis::Serializers do
     end
   end
 
-  describe '#[]' do
+  describe '#assoc' do
     it 'looks up serializers by module' do
       serializers = Readthis::Serializers.new
 
-      expect(serializers[Marshal]).to eq(0x1)
+      expect(serializers.assoc(Marshal)).to eq(0x1)
     end
   end
 
-  describe '#inverted' do
+  describe '#rassoc' do
     it 'inverts the current set of serializers' do
       serializers = Readthis::Serializers.new
 
-      expect(serializers.inverted).to include(
-        1 => Marshal
-      )
+      expect(serializers.rassoc(1)).to eq(Marshal)
     end
   end
 

--- a/spec/readthis_spec.rb
+++ b/spec/readthis_spec.rb
@@ -3,7 +3,7 @@ require 'readthis'
 RSpec.describe Readthis do
   describe '#serializers' do
     it 'lists currently configured serializers' do
-      expect(Readthis.serializers.modules).to include(Marshal, JSON)
+      expect(Readthis.serializers.marshals).to include(Marshal, JSON)
     end
   end
 end

--- a/spec/readthis_spec.rb
+++ b/spec/readthis_spec.rb
@@ -3,7 +3,7 @@ require 'readthis'
 RSpec.describe Readthis do
   describe '#serializers' do
     it 'lists currently configured serializers' do
-      expect(Readthis.serializers.keys).to include(Marshal, JSON)
+      expect(Readthis.serializers.modules).to include(Marshal, JSON)
     end
   end
 end

--- a/spec/readthis_spec.rb
+++ b/spec/readthis_spec.rb
@@ -1,0 +1,9 @@
+require 'readthis'
+
+RSpec.describe Readthis do
+  describe '#serializers' do
+    it 'lists currently configured serializers' do
+      expect(Readthis.serializers.keys).to include(Marshal, JSON)
+    end
+  end
+end


### PR DESCRIPTION
Introduces serializer customization. Usage is outlined in the README. Here's a quick summary:

```ruby
# Set custom serializers
Readthis.serializers << Oj
Readthis.serializers << MessagePack

# Freeze them to prevent further usage
Readthis.serializers.freeze!

# Reset back to the three defaults
Readthis.serializers.reset!
```

Addresses #18 @fabn