### PR TITLE
Handle case when nil is explicitly passed to fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fixed: Handle the case when `nil` is explicitly passed as options to `fetch`.
 - Changed: All errors now extend from a base `ReadthisError`.
 
 ## v1.0.0 2015-10-05

--- a/lib/readthis/cache.rb
+++ b/lib/readthis/cache.rb
@@ -138,6 +138,7 @@ module Readthis
     #   cache.fetch('today', force: true) # => nil
     #
     def fetch(key, options = {})
+      options ||= {}
       value = read(key, options) unless options[:force]
 
       if value.nil? && block_given?

--- a/spec/readthis/cache_spec.rb
+++ b/spec/readthis/cache_spec.rb
@@ -156,6 +156,11 @@ RSpec.describe Readthis::Cache do
 
       expect(cache.read('short-key')).to eq('other stuff')
     end
+
+    it 'gets an existing value when `options` are passed as nil' do
+      cache.write('great-key', 'great')
+      expect(cache.fetch('great-key', nil)).to eq('great')
+    end
   end
 
   describe '#read_multi' do


### PR DESCRIPTION
I ran in to this issue while using the active model serializers gem
version v0.10.0.rc3.

They default their options that get passed to the cache as nil if
none are set. Using an options hash doesn't guard against explicitly
passed parameters, in this case nil. That caused an error, shown in
the screenshot below.

I hope this helps :)

![screen shot 2015-10-15 at 11 56 14 pm](https://cloud.githubusercontent.com/assets/672057/10535626/3389c6ec-7399-11e5-9901-32cba2a80b7c.png)
