### PR TITLE
Fixed merged_options method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## Unreleased
 
+- Fixed: Stop overwriting specific options with the default options. [issue-28].
+  Discovered and fixed by @tobinibot.
 - Fixed: Handle the case when `nil` is explicitly passed as options to `fetch`.
 - Changed: All errors now extend from a base `ReadthisError`.
+
+[issue-28]: https://github.com/sorentwo/readthis/issues/28
 
 ## v1.0.0 2015-10-05
 

--- a/lib/readthis/cache.rb
+++ b/lib/readthis/cache.rb
@@ -352,7 +352,7 @@ module Readthis
     end
 
     def merged_options(options)
-      (options || {}).merge!(@options)
+      @options.merge(options || {})
     end
 
     def pool_options(options)

--- a/spec/readthis/cache_spec.rb
+++ b/spec/readthis/cache_spec.rb
@@ -54,6 +54,15 @@ RSpec.describe Readthis::Cache do
       sleep 1.01
       expect(cache.read('some-key')).to be_nil
     end
+    
+    it 'uses a custom expiration version 2' do
+      cache = Readthis::Cache.new(namespace: 'cache', expires_in: 86400)
+      cache.write('other-key', 'other-value', expires_in: 1)
+
+      expect(cache.read('other-key')).not_to be_nil
+      sleep 1.01
+      expect(cache.read('other-key')).to be_nil
+    end
 
     it 'expands non-string keys' do
       key_obj = double(cache_key: 'custom')


### PR DESCRIPTION
This PR addresses issue #27.

In the `merged_options` method, the order of the arguments was wrong; we want to merge the *specific* options into the *default* options, and not the other way around. The original code was overwriting the specific options hash with values from the default options hash.

```ruby
# original method
def merged_options(options)
    (options || {}).merge!(@options)
end

# fixed method
def merged_options(options)
    @options.merge(options || {})
end
```

There also doesn't seem to be any need to permanently update the specific options hash (returning a properly merged hash is good enough), so I didn't worry about copying that functionality over to the fixed method.

The reason the test suite didn't catch this is that the default `expires_in` period is 1 second and in the test for custom expiration, it *also* uses 1 second. I added a test which mirrors my setup (a high default and a short specific period), and the test suite passes successfully again after the code change.
