### PR TITLE
Add support for objects as :expires_in values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+- Added: The `:expires_in` option can now be an object which responds to the 
+  `to_i` method, rather than having to be a `Fixnum`. This is mainly to add
+  support for specifiying the `:expires_in` option by passing in 
+  `ActiveSupport::Duration` objects, although any object which responds to
+  `to_i` will work. Added by @tobinibot.
 - Fixed: Handle the case when `nil` is explicitly passed as options to `fetch`.
 - Changed: All errors now extend from a base `ReadthisError`.
 

--- a/lib/readthis/cache.rb
+++ b/lib/readthis/cache.rb
@@ -355,7 +355,7 @@ module Readthis
     end
 
     def merged_options(options)
-      @options.merge(options || {})
+      (options || {}).merge!(@options)
     end
 
     def pool_options(options)

--- a/lib/readthis/cache.rb
+++ b/lib/readthis/cache.rb
@@ -35,6 +35,9 @@ module Readthis
     #
     def initialize(options = {})
       @options = options
+      if @options[:expires_in] and @options[:expires_in].respond_to?(:to_i)
+        @options[:expires_in] = @options[:expires_in].to_i
+      end
 
       @entity = Readthis::Entity.new(
         marshal:   options.fetch(:marshal, Marshal),
@@ -352,7 +355,7 @@ module Readthis
     end
 
     def merged_options(options)
-      (options || {}).merge!(@options)
+      @options.merge(options || {})
     end
 
     def pool_options(options)

--- a/lib/readthis/cache.rb
+++ b/lib/readthis/cache.rb
@@ -355,6 +355,10 @@ module Readthis
     end
 
     def merged_options(options)
+      if options != nil and options[:expires_in] and options[:expires_in].respond_to?(:to_i)
+        options[:expires_in] = options[:expires_in].to_i
+      end
+      
       (options || {}).merge!(@options)
     end
 

--- a/spec/readthis/cache_spec.rb
+++ b/spec/readthis/cache_spec.rb
@@ -67,6 +67,22 @@ RSpec.describe Readthis::Cache do
       expect(cache.read('some-key')).to be_nil
     end
 
+    it 'uses an object for custom expiration' do
+      class FakeDuration
+        def to_i
+          2
+        end
+      end
+      
+      cache.write('some-key', 'some-value', expires_in: FakeDuration.new)
+
+      expect(cache.read('some-key')).not_to be_nil
+      sleep 1.01
+      expect(cache.read('some-key')).not_to be_nil
+      sleep 1.01
+      expect(cache.read('some-key')).to be_nil
+    end
+
     it 'expands non-string keys' do
       key_obj = double(cache_key: 'custom')
 

--- a/spec/readthis/cache_spec.rb
+++ b/spec/readthis/cache_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Readthis::Cache do
       sleep 1.01
       expect(cache.read('some-key')).to be_nil
     end
-    
+
     it 'expands non-string keys' do
       key_obj = double(cache_key: 'custom')
 

--- a/spec/readthis/cache_spec.rb
+++ b/spec/readthis/cache_spec.rb
@@ -67,15 +67,6 @@ RSpec.describe Readthis::Cache do
       expect(cache.read('some-key')).to be_nil
     end
     
-    it 'uses a custom expiration version 2' do
-      cache = Readthis::Cache.new(namespace: 'cache', expires_in: 86400)
-      cache.write('other-key', 'other-value', expires_in: 1)
-
-      expect(cache.read('other-key')).not_to be_nil
-      sleep 1.01
-      expect(cache.read('other-key')).to be_nil
-    end
-
     it 'expands non-string keys' do
       key_obj = double(cache_key: 'custom')
 

--- a/spec/readthis/cache_spec.rb
+++ b/spec/readthis/cache_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Readthis::Cache do
       expect(cache.options).to eq(namespace: 'cache', expires_in: 1)
     end
     
-    it 'handles ActiveSupport:Duration objects as expires_in values' do
+    it 'handles objects as expires_in values' do
       class FakeDuration
         def to_i
           120

--- a/spec/readthis/cache_spec.rb
+++ b/spec/readthis/cache_spec.rb
@@ -13,6 +13,18 @@ RSpec.describe Readthis::Cache do
 
       expect(cache.options).to eq(namespace: 'cache', expires_in: 1)
     end
+    
+    it 'handles ActiveSupport:Duration objects as expires_in values' do
+      class FakeDuration
+        def to_i
+          120
+        end
+      end
+      
+      cache = Readthis::Cache.new(namespace: 'cache', expires_in: FakeDuration.new)
+
+      expect(cache.options).to eq(namespace: 'cache', expires_in: 120)
+    end
   end
 
   describe '#pool' do
@@ -53,6 +65,15 @@ RSpec.describe Readthis::Cache do
       expect(cache.read('some-key')).not_to be_nil
       sleep 1.01
       expect(cache.read('some-key')).to be_nil
+    end
+    
+    it 'uses a custom expiration version 2' do
+      cache = Readthis::Cache.new(namespace: 'cache', expires_in: 86400)
+      cache.write('other-key', 'other-value', expires_in: 1)
+
+      expect(cache.read('other-key')).not_to be_nil
+      sleep 1.01
+      expect(cache.read('other-key')).to be_nil
     end
 
     it 'expands non-string keys' do


### PR DESCRIPTION
When configuring readthis, it would be nice to be able to pass in `ActiveSupport::Duration` objects as the `:expires_in` parameter, without having to manually call the `to_i` method on them.

This PR adds the ability to use objects that respond to the `to_i` method as the `:expires_in` parameter. As stated above, this is mainly to support `ActiveSupport::Duration` objects, but there could obviously be many other uses.