### PR TITLE
Fix a wrong argument in Readthis::Cache#read_multi

### DIFF
--- a/lib/readthis/cache.rb
+++ b/lib/readthis/cache.rb
@@ -212,7 +212,7 @@ module Readthis
       return {} if keys.empty?
 
       invoke(:read_multi, keys) do |store|
-        values = store.mget(mapping).map { |value| entity.load(value) }
+        values = store.mget(*mapping).map { |value| entity.load(value) }
 
         keys.zip(values).to_h
       end


### PR DESCRIPTION
This argument is wrong. [Redis#mget](https://github.com/redis/redis-rb/blob/v3.2.2/lib/redis.rb#L838) expects variable-length arguments of string.
There is no problem in the case of using Redis object. However, there
are problems in the case of another object having interfaces same as Redis object
(typically, a mock object as [mock_redis](https://github.com/brigade/mock_redis)).