### PR TITLE
duplicate object in passthrough dump to prevent mutation in entity compose

### DIFF
--- a/lib/readthis/passthrough.rb
+++ b/lib/readthis/passthrough.rb
@@ -3,7 +3,7 @@
 module Readthis
   module Passthrough
     def self.dump(value)
-      value
+      value.dup
     end
 
     def self.load(value)

--- a/spec/readthis/cache_spec.rb
+++ b/spec/readthis/cache_spec.rb
@@ -172,6 +172,12 @@ RSpec.describe Readthis::Cache do
       expect(cache.read('missing-key')).to eq(value)
     end
 
+    it 'returns computed value when using passthrough marshalling' do
+      cache = Readthis::Cache.new(marshal: Readthis::Passthrough)
+      result = cache.fetch('missing-key') { 'value for you' }
+      expect(result).to eq('value for you')
+    end
+
     it 'does not set for a missing key without a block' do
       expect(cache.fetch('missing-key')).to be_nil
     end

--- a/spec/readthis/passthrough_spec.rb
+++ b/spec/readthis/passthrough_spec.rb
@@ -1,15 +1,16 @@
 RSpec.describe Readthis::Passthrough do
+  let(:value) { 'skywalker' }
+
   describe '.load' do
     it 'passes through the provided value' do
-      value = Object.new
       expect(Readthis::Passthrough.load(value)).to eq(value)
     end
   end
 
   describe '.dump' do
     it 'passes through the provided value' do
-      value = Object.new
       expect(Readthis::Passthrough.dump(value)).to eq(value)
+      expect(Readthis::Passthrough.dump(value)).not_to be(value)
     end
   end
 end


### PR DESCRIPTION
storing a string using passthrough with `fetch` returns mutated string with flags if value wasn't stored before