### PR TITLE
take into account only first 3 bits on integer when inverting serializers

### DIFF
--- a/lib/readthis/serializers.rb
+++ b/lib/readthis/serializers.rb
@@ -13,7 +13,7 @@ module Readthis
     }.freeze
 
     # The hard serializer limit, based on the number of possible values within
-    # a single 8bit integer.
+    # a single 3bit integer.
     SERIALIZER_LIMIT = 7
 
     attr_reader :serializers, :inverted
@@ -96,7 +96,7 @@ module Readthis
     #   serializers.rassoc(1) #=> Marshal
     #
     def rassoc(flag)
-      inverted[flag & inverted.length]
+      inverted[flag & SERIALIZER_LIMIT]
     end
 
     # @private

--- a/spec/readthis/serializers_spec.rb
+++ b/spec/readthis/serializers_spec.rb
@@ -46,17 +46,28 @@ RSpec.describe Readthis::Serializers do
   end
 
   describe '#rassoc' do
-    it 'inverts the current set of serializers' do
-      serializers = Readthis::Serializers.new
+    let(:serializers) { Readthis::Serializers.new }
 
+    it 'inverts the current set of serializers' do
       expect(serializers.rassoc(1)).to eq(Marshal)
     end
 
     it 'returns custom serializers' do
-      serializers = Readthis::Serializers.new
       serializers << CustomSerializer
-
       expect(serializers.rassoc(4)).to eq(CustomSerializer)
+    end
+
+    it 'inverts default serializers after adding custom one' do
+      serializers << CustomSerializer
+      expect(serializers.rassoc(1)).to eq(Marshal)
+      expect(serializers.rassoc(3)).to eq(JSON)
+    end
+
+    it 'takes into account only first 3 bytes of passed integer' do
+      expect(serializers.rassoc(1)).to eq(Marshal)
+      expect(serializers.rassoc(11)).to eq(JSON)
+      serializers << CustomSerializer
+      expect(serializers.rassoc(12)).to eq(CustomSerializer)
     end
   end
 


### PR DESCRIPTION
I noticed the issue after adding Oj serializer and trying to use Marshal. Instead of original object it would return a string. Turns out serializer couldn't be detected. That's because it would do `1 & 4` in `rassoc` which is `0`. Original implementation works for `3 = "11"`, and `4="100"` works for 4 but cuts off everything below.  Instead we should extract first 3 bytes (7 = "111") from passed integer regardless of serializers array length.
Thanks @epilgrim for helping me out with this one.