### PR TITLE
fix the guard for max amount of serializers

### DIFF
--- a/lib/readthis/serializers.rb
+++ b/lib/readthis/serializers.rb
@@ -41,7 +41,7 @@ module Readthis
       case
       when serializers.frozen?
         raise SerializersFrozenError
-      when serializers.length > SERIALIZER_LIMIT
+      when serializers.length >= SERIALIZER_LIMIT
         raise SerializersLimitError
       else
         @serializers[serializer] = flags.max.succ

--- a/spec/readthis/serializers_spec.rb
+++ b/spec/readthis/serializers_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe Readthis::Serializers do
 
     it 'prevents more than seven serializers' do
       serializers = Readthis::Serializers.new
-
+      serializers << Class.new until serializers.flags.length >= 7
       expect do
-        10.times { serializers << Class.new }
+        serializers << Class.new
       end.to raise_error(Readthis::SerializersLimitError)
     end
   end


### PR DESCRIPTION
While reviewing #45, I just spotted that the guard is wrong, as allows up until 8 serializers.
At the same time, the test was wrong, as adding up until 10 serializers more doesn't ensure that we can have up to 7