### PR TITLE
Skip the provided block at fetch method if write nil value.

### DIFF
--- a/lib/readthis/cache.rb
+++ b/lib/readthis/cache.rb
@@ -205,11 +205,16 @@ module Readthis
     #
     def fetch(key, options = {})
       options ||= {}
-      value = read(key, options) unless options[:force]
 
-      if value.nil? && block_given?
+      if options[:force]
         value = yield(key)
         write(key, value, options)
+      else
+        value = read(key, options)
+        if value.nil? && block_given? && !exist?(key, options)
+          value = yield(key)
+          write(key, value, options)
+        end
       end
 
       value

--- a/spec/readthis/cache_spec.rb
+++ b/spec/readthis/cache_spec.rb
@@ -172,6 +172,12 @@ RSpec.describe Readthis::Cache do
       expect(cache.read('missing-key')).to eq(value)
     end
 
+    it 'skips the provided block if write nil value' do
+      cache.write('short-key', nil)
+      result = cache.fetch('short-key') { 'skip this block' }
+      expect(result).to be_nil
+    end
+
     it 'returns computed value when using passthrough marshalling' do
       cache = Readthis::Cache.new(marshal: Readthis::Passthrough)
       result = cache.fetch('missing-key') { 'value for you' }


### PR DESCRIPTION
This PR is to skip the provided block in `fetch` method if write `nil` value.
The behavior same as `ActiveSupport::Cache::MemoryStore`.

```rb
cache.write('short-key', nil)
result = cache.fetch('short-key') { 'skip this block' } # => expect nil
```