### PR TITLE
Upgrade to redis-rb 4.0

### DIFF
--- a/readthis.gemspec
+++ b/readthis.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(spec)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'redis',           '~> 3.0'
+  spec.add_dependency 'redis',           '~> 4.0'
   spec.add_dependency 'connection_pool', '~> 2.1'
 
   spec.add_development_dependency 'activesupport', '> 4.0'

--- a/readthis.gemspec
+++ b/readthis.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(spec)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'redis',           '~> 4.0'
+  spec.add_dependency 'redis',           '>= 3.0', '< 5.0'
   spec.add_dependency 'connection_pool', '~> 2.1'
 
   spec.add_development_dependency 'activesupport', '> 4.0'

--- a/spec/readthis/cache_spec.rb
+++ b/spec/readthis/cache_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Readthis::Cache do
       cache = Readthis::Cache.new(redis: { driver: :hiredis })
 
       cache.pool.with do |client|
-        expect(client.client.driver).to be(Redis::Connection::Hiredis)
+        expect(client._client.driver).to be(Redis::Connection::Hiredis)
       end
     end
   end


### PR DESCRIPTION
I updated the gemspec to point to `~> 4.0`. The only breakage I saw was in cache_spec on how to access the low level client.

https://github.com/redis/redis-rb/blob/master/CHANGELOG.md#40

`Added support for CLIENT commands. The lower-level client can be accessed via Redis#_client.`