### PR TITLE
add Errno::EADDRNOTAVAIL to redis connect errors

### DIFF
--- a/lib/readthis/cache.rb
+++ b/lib/readthis/cache.rb
@@ -472,7 +472,7 @@ module Readthis
       instrument(operation, key) do
         pool.with(&block)
       end
-    rescue Redis::BaseError => error
+    rescue Redis::BaseError, Errno::EADDRNOTAVAIL => error
       raise error unless Readthis.fault_tolerant?
     end
 

--- a/spec/readthis/cache_spec.rb
+++ b/spec/readthis/cache_spec.rb
@@ -225,6 +225,16 @@ RSpec.describe Readthis::Cache do
 
       expect(computed).to eq('computed')
     end
+
+    it 'serves computed content when the cache is not available and tolerance is enabled' do
+      Readthis.fault_tolerant = true
+
+      allow(cache.pool).to receive(:with).and_raise(Errno::EADDRNOTAVAIL)
+
+      computed = cache.fetch('error-key') { 'computed' }
+
+      expect(computed).to eq('computed')
+    end
   end
 
   describe '#read_multi' do


### PR DESCRIPTION
Reported on redis-rb https://github.com/redis/redis-rb/pull/744
Until its merged we can rescue low-level exception `Errno::EADDRNOTAVAIL` (Address not available)
Cheers